### PR TITLE
Make errors public to allow for error matching from the outside

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod errors;
+pub mod errors;
 mod packet;
 mod ping;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-pub mod errors;
+mod errors;
 mod packet;
 mod ping;
 
 pub use crate::ping::{dgramsock, ping, rawsock};
+pub use crate::errors::Error;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code maintainability by allowing external use of the `Error` type from the `errors` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->