### PR TITLE
📝 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Ping function implemented in rust.
 
 ## dgram sock and raw sock
 
-Sending an ICMP package should create a socket with type 'raw' on most platforms. And most of these platforms require special privileges. Basically, it needs to run with sudo on Linux to create a 'raw' socket.
+Sending an ICMP package should create a socket of type `raw` on most platforms. And most of these platforms require special privileges. Basically, it needs to run with sudo on Linux to create a `raw` socket.
 
-These requirements introduce security risks, so on modern platforms, 'unprivileged ping' has been introduced, with socket type 'dgram'. So there are two mods in this crate, rawsock and dgramsock, which have the same function ping. And the global ping function is just an alias to the rawsock::ping. You can pick the one which is suitable for your use case.
+These requirements introduce security risks, so on modern platforms, `unprivileged ping` has been introduced, with socket type `dgram`. So there are two mods in this crate, rawsock and dgramsock, which have the same function `ping`. And the global ping function is just an alias for the `rawsock::ping`. You can pick the one which is suitable for your use case.
 
-For Linux users, although modern kernels support dgram, in some distributions (like Arch), it's disabled by default. More details: https://wiki.archlinux.org/title/sysctl#Allow_unprivileged_users_to_create_IPPROTO_ICMP_sockets
+For Linux users, although modern kernels support ping with `dgram`, in some distributions (like Arch), it's disabled by default. More details: https://wiki.archlinux.org/title/sysctl#Allow_unprivileged_users_to_create_IPPROTO_ICMP_sockets
 
 ## License
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README to explain the use of `raw` and `dgram` socket types for ICMP packages and the associated privileges required on different platforms.
	- Provided guidance on choosing between `rawsock` and `dgramsock` modules based on user needs and platform capabilities.
	- Included a note for Linux users regarding potential distribution-specific restrictions and a resource link for further details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->