### PR TITLE
Make function std::ping::ping concurrency safe #7

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,9 +6,9 @@ pub enum Error {
     InvalidProtocol,
     #[error("internal error")]
     InternalError,
-    #[error("decode v4 error")]
+    #[error("Decode V4 error occurred while processing the IPv4 packet.")]
     DecodeV4Error,
-    #[error("decode echo reply error")]
+    #[error("Decode echo reply error occurred while processing the ICMP echo reply.")]
     DecodeEchoReplyError,
     #[error("io error: {error}")]
     IoError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,10 @@ pub enum Error {
     InvalidProtocol,
     #[error("internal error")]
     InternalError,
+    #[error("decode v4 error")]
+    DecodeV4Error,
+    #[error("decode echo reply error")]
+    DecodeEchoReplyError,
     #[error("io error: {error}")]
     IoError {
         #[from]

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -72,16 +72,16 @@ fn ping_with_socktype(
         let reply = if dest.is_ipv4() {
             let ipv4_packet = match IpV4Packet::decode(&buffer) {
                 Ok(packet) => packet,
-                Err(_) => return Err(Error::InternalError.into()),
+                Err(_) => return Err(Error::DecodeV4Error.into()),
             };
             match EchoReply::decode::<IcmpV4>(ipv4_packet.data) {
                 Ok(reply) => reply,
-                Err(_) => return Err(Error::InternalError.into()),
+                Err(_) => return Err(Error::DecodeEchoReplyError.into()),
             }
         } else {
             match EchoReply::decode::<IcmpV6>(&buffer) {
                 Ok(reply) => reply,
-                Err(_) => return Err(Error::InternalError.into()),
+                Err(_) => return Err(Error::DecodeEchoReplyError.into()),
             }
         };
 

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -91,7 +91,10 @@ fn ping_with_socktype(
         }
 
         // if ident is not correct check if timeout is over
-        time_elapsed = SystemTime::now().duration_since(time_start).expect("Clock may have gone backwards");
+        time_elapsed = match SystemTime::now().duration_since(time_start) {
+            Ok(reply) => reply,
+            Err(_) => return Err(Error::InternalError.into()),
+        };
         if time_elapsed >= timeout {
             let error = std::io::Error::new(std::io::ErrorKind::TimedOut, "Timeout occured");
             return Err(Error::IoError { error: (error) });

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
-use std::time::Duration;
+use std::time::{Duration,SystemTime};
 
 use rand::random;
 use socket2::{Domain, Protocol, Socket, Type};
@@ -21,9 +21,11 @@ fn ping_with_socktype(
     seq_cnt: Option<u16>,
     payload: Option<&Token>,
 ) -> Result<(), Error> {
+    let time_start = SystemTime::now();
+
     let timeout = match timeout {
-        Some(timeout) => Some(timeout),
-        None => Some(Duration::from_secs(4)),
+        Some(timeout) => timeout,
+        None => Duration::from_secs(4),
     };
 
     let dest = SocketAddr::new(addr, 0);
@@ -55,32 +57,46 @@ fn ping_with_socktype(
         socket.set_unicast_hops_v6(ttl.unwrap_or(64))?;
     }
 
-    socket.set_write_timeout(timeout)?;
+    socket.set_write_timeout(Some(timeout))?;
 
     socket.send_to(&mut buffer, &dest.into())?;
 
-    socket.set_read_timeout(timeout)?;
+    // loop until either an echo with correct ident was received or timeout is over
+    let mut time_elapsed = Duration::from_secs(0);
+    loop {
+        socket.set_read_timeout(Some(timeout - time_elapsed))?;
 
-    let mut buffer: [u8; 2048] = [0; 2048];
-    socket.read(&mut buffer)?;
+        let mut buffer: [u8; 2048] = [0; 2048];
+        socket.read(&mut buffer)?;
 
-    let _reply = if dest.is_ipv4() {
-        let ipv4_packet = match IpV4Packet::decode(&buffer) {
-            Ok(packet) => packet,
-            Err(_) => return Err(Error::InternalError.into()),
+        let reply = if dest.is_ipv4() {
+            let ipv4_packet = match IpV4Packet::decode(&buffer) {
+                Ok(packet) => packet,
+                Err(_) => return Err(Error::InternalError.into()),
+            };
+            match EchoReply::decode::<IcmpV4>(ipv4_packet.data) {
+                Ok(reply) => reply,
+                Err(_) => return Err(Error::InternalError.into()),
+            }
+        } else {
+            match EchoReply::decode::<IcmpV6>(&buffer) {
+                Ok(reply) => reply,
+                Err(_) => return Err(Error::InternalError.into()),
+            }
         };
-        match EchoReply::decode::<IcmpV4>(ipv4_packet.data) {
-            Ok(reply) => reply,
-            Err(_) => return Err(Error::InternalError.into()),
-        }
-    } else {
-        match EchoReply::decode::<IcmpV6>(&buffer) {
-            Ok(reply) => reply,
-            Err(_) => return Err(Error::InternalError.into()),
-        }
-    };
 
-    return Ok(());
+        if reply.ident == request.ident {
+            // received correct ident
+            return Ok(());
+        }
+
+        // if ident is not correct check if timeout is over
+        time_elapsed = SystemTime::now().duration_since(time_start).expect("Clock may have gone backwards");
+        if time_elapsed >= timeout {
+            let error = std::io::Error::new(std::io::ErrorKind::TimedOut, "Timeout occured");
+            return Err(Error::IoError { error: (error) });
+        }
+    }
 }
 
 pub mod rawsock {


### PR DESCRIPTION
Took the PR [from](https://github.com/aisk/rust-ping/pull/7) over and changed the error handling. However i can not run the tests on the branch or on master so i'm unsure if the code @michael-hartman provided is sound. 

> The function ping so far did not check the ident received. As a consequence the function ping might returned wrong results when used simultaneously from different threads, see https://github.com/aisk/rust-ping/issues/6 for more details.

> This commit fixes the issue by checking the ident of the reply and comparing it with the expected ident.

> Changes:

> This avoids an additional error check in new code.
> Receive echo in a loop until either the correct ident was received or a timeout occured.
> I have tested the changes and they seem to work for me. Let me know if something still needs to be changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the ping operation with time tracking and improved timeout handling.
	- Implemented a more robust loop for monitoring replies and timeouts during ping operations.
	- Refined error handling for better clarity during timeouts.
	- Added two new error types for decoding errors related to v4 and echo replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->