### PR TITLE
 🐛 Ignore the invalid UDP packet

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -76,12 +76,12 @@ fn ping_with_socktype(
             };
             match EchoReply::decode::<IcmpV4>(ipv4_packet.data) {
                 Ok(reply) => reply,
-                Err(_) => return Err(Error::DecodeEchoReplyError.into()),
+                Err(_) => continue,
             }
         } else {
             match EchoReply::decode::<IcmpV6>(&buffer) {
                 Ok(reply) => reply,
-                Err(_) => return Err(Error::DecodeEchoReplyError.into()),
+                Err(_) => continue,
             }
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in network ping functionality to ensure continuous operation even when certain echo replies cannot be decoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->