### PR TITLE
Added support for specifying source interface.

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -15,6 +15,7 @@ type Token = [u8; TOKEN_SIZE];
 fn ping_with_socktype(
     socket_type: Type,
     addr: IpAddr,
+    iface: Option<&[u8]>,
     timeout: Option<Duration>,
     ttl: Option<u32>,
     ident: Option<u16>,
@@ -50,6 +51,8 @@ fn ping_with_socktype(
         }
         Socket::new(Domain::IPV6, socket_type, Some(Protocol::ICMPV6))?
     };
+
+    socket.bind_device(iface)?;
 
     if dest.is_ipv4() {
         socket.set_ttl(ttl.unwrap_or(64))?;
@@ -106,13 +109,14 @@ pub mod rawsock {
     use super::*;
     pub fn ping(
         addr: IpAddr,
+        iface: Option<&[u8]>,
         timeout: Option<Duration>,
         ttl: Option<u32>,
         ident: Option<u16>,
         seq_cnt: Option<u16>,
         payload: Option<&Token>,
     ) -> Result<(), Error> {
-        return ping_with_socktype(Type::RAW, addr, timeout, ttl, ident, seq_cnt, payload);
+        return ping_with_socktype(Type::RAW, addr, iface, timeout, ttl, ident, seq_cnt, payload);
     }
 }
 
@@ -121,22 +125,24 @@ pub mod dgramsock {
     pub fn ping(
         addr: IpAddr,
         timeout: Option<Duration>,
+        iface: Option<&[u8]>,
         ttl: Option<u32>,
         ident: Option<u16>,
         seq_cnt: Option<u16>,
         payload: Option<&Token>,
     ) -> Result<(), Error> {
-        return ping_with_socktype(Type::DGRAM, addr, timeout, ttl, ident, seq_cnt, payload);
+        return ping_with_socktype(Type::DGRAM, addr, iface, timeout, ttl, ident, seq_cnt, payload);
     }
 }
 
 pub fn ping(
     addr: IpAddr,
+    iface: Option<&[u8]>,
     timeout: Option<Duration>,
     ttl: Option<u32>,
     ident: Option<u16>,
     seq_cnt: Option<u16>,
     payload: Option<&Token>,
 ) -> Result<(), Error> {
-    return rawsock::ping(addr, timeout, ttl, ident, seq_cnt, payload);
+    return rawsock::ping(addr, iface, timeout, ttl, ident, seq_cnt, payload);
 }


### PR DESCRIPTION
My program needed to ping from specific interfaces, so I added the required functionality.

Testing it on amd64 Debian 12, showed:
```
$ sudo tcpdump -iany -n icmp
tcpdump: data link type LINUX_SLL2
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 262144 bytes
07:26:23.592117 wlo1  Out IP 192.168.1.117 > 1.1.1.1: ICMP echo request, id 3, seq 5, length 32
07:26:23.611290 wlo1  In  IP 1.1.1.1 > 192.168.1.117: ICMP echo reply, id 3, seq 5, length 32
07:26:23.611617 enp2s0 Out IP 192.168.1.106 > 1.1.1.1: ICMP echo request, id 3, seq 5, length 32
07:26:23.627724 enp2s0 In  IP 1.1.1.1 > 192.168.1.106: ICMP echo reply, id 3, seq 5, length 32
```