### PR TITLE
fix(ping.rs): ignore bind_device on macos

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -238,7 +238,10 @@ impl<'a> Ping<'a> {
             self.ident,
             self.seq_cnt,
             self.payload,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             self.bind_device,
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            None,
         );
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -80,6 +80,7 @@ fn builder_api2() {
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn bind_device() {
     let addr = "127.0.0.1".parse().unwrap();
     let timeout = Duration::from_secs(1);


### PR DESCRIPTION
- Fix build on macOS.

Current version:
<img width="922" height="585" alt="image" src="https://github.com/user-attachments/assets/794f1b8d-0187-4cd5-a652-765d694a7051" />

After fix:
<img width="901" height="884" alt="image" src="https://github.com/user-attachments/assets/4e008322-ba01-4766-94de-7ebff32fcd57" />
