### PR TITLE
chore(.github): add CI for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,6 @@ jobs:
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
         run: sudo cargo test --verbose
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
+        run: sudo -E env "PATH=$PATH" cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        run: cargo test --verbose
+      - name: Run tests (macOS)
+        if: runner.os == 'macOS'
+        run: sudo cargo test --verbose

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,15 @@
-use std::time::Duration;
 use rand::random;
+use socket2::{Domain, Protocol, Socket, Type};
+use std::time::Duration;
+
+macro_rules! skip_if_no_capability {
+    () => {
+        if Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::ICMPV4)).is_err() {
+            eprintln!("Skipping test: raw socket capability not available");
+            return;
+        }
+    };
+}
 
 #[test]
 fn basic() {
@@ -34,6 +44,7 @@ fn basic_v6() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn basic_dgram() {
+    skip_if_no_capability!();
     let addr = "127.0.0.1".parse().unwrap();
     let timeout = Duration::from_secs(1);
     ping::dgramsock::ping(
@@ -50,6 +61,7 @@ fn basic_dgram() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn basic_dgram_v6() {
+    skip_if_no_capability!();
     let addr = "::1".parse().unwrap();
     let timeout = Duration::from_secs(1);
     ping::dgramsock::ping(
@@ -65,6 +77,7 @@ fn basic_dgram_v6() {
 
 #[test]
 fn builder_api1() {
+    skip_if_no_capability!();
     let addr = "127.0.0.1".parse().unwrap();
     let timeout = Duration::from_secs(1);
     let mut pinger = ping::new(addr);
@@ -74,6 +87,7 @@ fn builder_api1() {
 
 #[test]
 fn builder_api2() {
+    skip_if_no_capability!();
     let addr = "127.0.0.1".parse().unwrap();
     let timeout = Duration::from_secs(1);
     ping::new(addr).timeout(timeout).ttl(42).send().unwrap();
@@ -84,5 +98,11 @@ fn builder_api2() {
 fn bind_device() {
     let addr = "127.0.0.1".parse().unwrap();
     let timeout = Duration::from_secs(1);
-    ping::new(addr).timeout(timeout).ttl(42).bind_device("lo").socket_type(ping::SocketType::RAW).send().unwrap();
+    ping::new(addr)
+        .timeout(timeout)
+        .ttl(42)
+        .bind_device("lo")
+        .socket_type(ping::SocketType::RAW)
+        .send()
+        .unwrap();
 }


### PR DESCRIPTION
Add GitHub Action for cargo test.
Currently it works on Windows and macOS. But I encounterd an issue on Linux image. 
I tried commands like:
```YAML
- name: Run tests (Linux)
  if: runner.os == 'Linux'
  run: |
    sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
    sudo sysctl -w net.ipv4.ip_unprivileged_port_start=0
    sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
    sudo -E env "PATH=$PATH" timeout 30 cargo test --verbose
```
Will face Error like `EWOULDBLOCK` and `DecodeV4Error`.
I am not sure what to do to solve this issue right now.


<details><summary>Ubuntu CI Log</summary>

```
net.ipv4.ping_group_range = 0 2147483647
net.ipv4.ip_unprivileged_port_start = 0
net.ipv6.conf.all.disable_ipv6 = 0
       Fresh libc v0.2.174
       Fresh unicode-ident v1.0.18
       Fresh cfg-if v1.0.1
       Fresh proc-macro2 v1.0.95
       Fresh getrandom v0.2.16
       Fresh zerocopy v0.8.26
       Fresh quote v1.0.40
       Fresh rand_core v0.6.4
       Fresh socket2 v0.4.10
       Fresh ppv-lite86 v0.2.21
       Fresh syn v2.0.104
       Fresh rand_chacha v0.3.1
       Fresh thiserror-impl v1.0.69
       Fresh rand v0.8.5
       Fresh thiserror v1.0.69
warning: fields `seq_cnt` and `payload` are never read
  --> src/packet/icmp.rs:65:9
   |
63 | pub struct EchoReply<'a> {
   |            --------- fields in this struct
64 |     pub ident: u16,
65 |     pub seq_cnt: u16,
   |         ^^^^^^^
66 |     pub payload: &'a [u8],
   |         ^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field `protocol` is never read
  --> src/packet/ipv4.rs:32:9
   |
31 | pub struct IpV4Packet<'a> {
   |            ---------- field in this struct
32 |     pub protocol: IpV4Protocol,
   |         ^^^^^^^^

   Compiling ping v0.6.1 (/home/runner/work/rust-ping/rust-ping)
warning: `ping` (lib) generated 2 warnings
     Running `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name ping --edition=2018 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=3d8a7d58ac3d3304 -C extra-filename=-0d33acbcbd41462d --out-dir /home/runner/work/rust-ping/rust-ping/target/debug/deps -C incremental=/home/runner/work/rust-ping/rust-ping/target/debug/incremental -L dependency=/home/runner/work/rust-ping/rust-ping/target/debug/deps --extern rand=/home/runner/work/rust-ping/rust-ping/target/debug/deps/librand-2adefde1f1492a1f.rlib --extern socket2=/home/runner/work/rust-ping/rust-ping/target/debug/deps/libsocket2-5031bd904698c012.rlib --extern thiserror=/home/runner/work/rust-ping/rust-ping/target/debug/deps/libthiserror-374ec292e5d7ef81.rlib`
     Running `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name tests --edition=2018 tests/tests.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=b60a54e2232920d6 -C extra-filename=-06f5e514ed36fb29 --out-dir /home/runner/work/rust-ping/rust-ping/target/debug/deps -C incremental=/home/runner/work/rust-ping/rust-ping/target/debug/incremental -L dependency=/home/runner/work/rust-ping/rust-ping/target/debug/deps --extern ping=/home/runner/work/rust-ping/rust-ping/target/debug/deps/libping-69dd74907488d944.rlib --extern rand=/home/runner/work/rust-ping/rust-ping/target/debug/deps/librand-2adefde1f1492a1f.rlib --extern socket2=/home/runner/work/rust-ping/rust-ping/target/debug/deps/libsocket2-5031bd904698c012.rlib --extern thiserror=/home/runner/work/rust-ping/rust-ping/target/debug/deps/libthiserror-374ec292e5d7ef81.rlib`
warning: `ping` (lib test) generated 2 warnings (2 duplicates)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.20s
     Running `/home/runner/work/rust-ping/rust-ping/target/debug/deps/ping-0d33acbcbd41462d`

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running `/home/runner/work/rust-ping/rust-ping/target/debug/deps/tests-06f5e514ed36fb29`

running 7 tests
test basic_v6 ... ok
test basic ... ok
test basic_dgram ... FAILED
test bind_device ... ok
test builder_api2 ... FAILED
test builder_api1 ... FAILED
test basic_dgram_v6 ... FAILED

failures:

---- basic_dgram stdout ----

thread 'basic_dgram' panicked at tests/tests.rs:47:6:
called `Result::unwrap()` on an `Err` value: DecodeV4Error
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- builder_api2 stdout ----

thread 'builder_api2' panicked at tests/tests.rs:79:53:
called `Result::unwrap()` on an `Err` value: DecodeV4Error

---- builder_api1 stdout ----

thread 'builder_api1' panicked at tests/tests.rs:72:19:
called `Result::unwrap()` on an `Err` value: DecodeV4Error

---- basic_dgram_v6 stdout ----

thread 'basic_dgram_v6' panicked at tests/tests.rs:63:6:
called `Result::unwrap()` on an `Err` value: IoError { error: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" } }


failures:
    basic_dgram
    basic_dgram_v6
    builder_api1
    builder_api2

test result: FAILED. 3 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.01s

error: test failed, to rerun pass `--test tests`
```

</details> 