### PR TITLE
Add derive debug, clone, copy to socket type enum

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -12,11 +12,13 @@ const TOKEN_SIZE: usize = 24;
 const ECHO_REQUEST_BUFFER_SIZE: usize = ICMP_HEADER_SIZE + TOKEN_SIZE;
 type Token = [u8; TOKEN_SIZE];
 
+#[derive(Clone, Copy, Debug)]
 pub enum SocketType {
     RAW,
     DGRAM,
 }
 
+#[derive(Debug)]
 pub struct PingResult {
     pub elapsed_time: Duration
 }


### PR DESCRIPTION
For your consideration.

Would just be useful to me to have these derivation while I use this lib.

Thx